### PR TITLE
feat: ChatServer first Implementation

### DIFF
--- a/src/main/java/org/chatServer/Main.java
+++ b/src/main/java/org/chatServer/Main.java
@@ -1,7 +1,21 @@
 package org.chatServer;
 
+import org.chatServer.broker.BroadCasterImpl;
+import org.chatServer.server.Server;
+
 public class Main {
     public static void main(String[] args) {
-        System.out.println("Hello, World!");
+
+        // final int SERVER_PORT = Integer.parseInt(args[0]);
+        final int SERVER_PORT = 9091;
+        // Set<ClientHandler> subs = ConcurrentHashMap.newKeySet();
+        BroadCasterImpl broker = new BroadCasterImpl();
+        Server server = new Server(SERVER_PORT, broker, 16);
+
+        try {
+            server.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/org/chatServer/broker/BroadCaster.java
+++ b/src/main/java/org/chatServer/broker/BroadCaster.java
@@ -1,0 +1,11 @@
+package org.chatServer.broker;
+
+import org.chatServer.server.ClientHandler;
+
+public interface BroadCaster {
+    void register(ClientHandler client);
+    void unregister(ClientHandler client);
+    void broadcast(String message);
+    int getSize();
+    void shutdown();
+}

--- a/src/main/java/org/chatServer/broker/BroadCasterImpl.java
+++ b/src/main/java/org/chatServer/broker/BroadCasterImpl.java
@@ -1,0 +1,54 @@
+package org.chatServer.broker;
+
+import org.chatServer.server.ClientHandler;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BroadCasterImpl implements BroadCaster {
+
+    private final Set<ClientHandler> clients;
+    private volatile boolean accepting = true;
+
+    public BroadCasterImpl() {
+        this.clients = ConcurrentHashMap.newKeySet();
+    }
+
+    @Override
+    public void register(ClientHandler client) {
+        if(!accepting) { return; }
+
+        clients.add(client);
+        System.out.println("[BROADCASTER] Registered: " + client.getRemote());
+    }
+
+    @Override
+    public void unregister(ClientHandler client) {
+        clients.remove(client);
+        System.out.println("[BROADCASTER] Registered: " + client.getRemote());
+    }
+
+    @Override
+    public void broadcast(String message) {
+        for(ClientHandler client : clients) {
+            if (!client.enqueue(message)) {
+                // 전송 불가/종료 상태인 경우 즉시 탈퇴
+                unregister(client);
+            }
+        }
+    }
+
+    @Override
+    public int getSize() {
+        return clients.size();
+    }
+
+    @Override
+    public void shutdown() {
+        accepting = false;
+        for (ClientHandler client : clients) {
+            try { client.closeQuietly(); } catch (Exception ignored) {}
+        }
+        clients.clear();
+    }
+}

--- a/src/main/java/org/chatServer/server/ClientHandler.java
+++ b/src/main/java/org/chatServer/server/ClientHandler.java
@@ -1,0 +1,111 @@
+package org.chatServer.server;
+
+import org.chatServer.broker.BroadCaster;
+import org.chatServer.util.StringValidateUtil;
+
+import java.io.*;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class ClientHandler implements Runnable {
+    private Socket socket;
+    private BroadCaster broadCaster;
+
+    // 쓰기 전용 큐 + writer 스레드(단일 writer 보장)
+    private final BlockingQueue<String> outbox = new LinkedBlockingQueue<>();
+    private volatile boolean running = true;
+
+    // 닉네임(선택): 최초 입력 없으면 원격 주소
+    private volatile String nickname;
+
+    ClientHandler(Socket socket, BroadCaster broadCaster, String nickname) {
+        this.socket = socket;
+        this.broadCaster = broadCaster;
+        setClientNickname(nickname);
+    }
+
+    /**
+     * 외부(브로드캐스터)가 메시지를 넣는 진입점.
+     * @return 큐에 성공적으로 넣었는지
+     */
+    public boolean enqueue(String msg) {
+        return running && outbox.offer(msg);
+    }
+
+    public void run() {
+        Thread writerThread = null;
+        try (
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                PrintWriter writer = new PrintWriter(
+                        new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8)),
+                        true)
+        ) {
+            // Write 전용 쓰레드를 분기한다
+            // enqueue를 통해 메시지 outbox 에 들어온 메시지 내용을 전달한다
+            writerThread = new Thread(() -> {
+                try {
+                    while (running) {
+                        String msg = outbox.take();
+                        writer.println(msg);
+                    }
+                } catch (InterruptedException ignored) {
+                } finally {
+                    // writer가 끝날 때 소켓 종료 유도
+                    try { socket.shutdownOutput(); } catch (IOException ignored) {}
+                }
+            }, "writer-" + socket.getPort());
+
+            writerThread.start();
+
+            // 환영/도움말
+            writer.println("Welcome! /nick <name>, /quit");
+            broadCaster.broadcast("** " + nickname + " joined (" + broadCaster.getSize() + " online) **");
+
+            // 읽기 루프
+            String line;
+            while(running && (line = reader.readLine()) != null) {
+                if (line.isBlank()) continue;
+
+                if(StringValidateUtil.validateQuitCommand(line)) {
+                    writer.println("Disconnected!");
+                    break;
+                } else {
+                    // 일반 매시지 브로드캐스팅
+                    String payload = "[" + nickname + "] " + line;
+                    broadCaster.broadcast(payload);
+                }
+
+
+            }
+
+        } catch ( IOException e ) {
+            System.err.println("[CLIENT] I/O error (" + nickname + "): " + e.getMessage());
+        } finally {
+            closeQuietly();
+            if (writerThread != null) writerThread.interrupt();
+            broadCaster.unregister(this);
+            broadCaster.broadcast("** " + nickname + " left **");
+        }
+    }
+
+    private void setClientNickname(String nickname) {
+        if(StringValidateUtil.validateClientNickname(nickname)) {
+            this.nickname = nickname;
+        } else {
+            this.nickname = socket.getRemoteSocketAddress().toString();
+        }
+    }
+
+    public void closeQuietly() {
+        running = false;
+        try { socket.close(); } catch (IOException ignored) {}
+    }
+
+    public String getRemote() {
+        return socket.getRemoteSocketAddress().toString();
+    }
+
+}

--- a/src/main/java/org/chatServer/server/Server.java
+++ b/src/main/java/org/chatServer/server/Server.java
@@ -1,0 +1,91 @@
+package org.chatServer.server;
+
+import org.chatServer.broker.BroadCaster;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.*;
+
+public class Server {
+
+    private final int port;
+    private final BroadCaster broadcaster;
+    private final ExecutorService pool;
+    private volatile boolean running = false;
+    private ServerSocket serverSocket;
+
+
+    public Server(int port, BroadCaster broadcaster, int maxThreads) {
+        this.port = port;
+        this.broadcaster = broadcaster;
+        this.pool = new ThreadPoolExecutor(
+                Math.max(4, Math.min(16, maxThreads / 2)), // core
+                maxThreads,                                 // max
+                60L, //  keepAliveTime
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                new ThreadFactory() {
+                    private final ThreadFactory def = Executors.defaultThreadFactory();
+                    @Override public Thread newThread(Runnable r) {
+                        Thread t = def.newThread(r);
+                        t.setName("client-handler-" + t.getId());
+                        t.setDaemon(false);
+                        return t;
+                    }
+                },
+                new ThreadPoolExecutor.CallerRunsPolicy() // 임계 시 호출 스레드가 수행
+        );
+
+    }
+
+    public void start() throws IOException {
+        running = true;
+        serverSocket = new ServerSocket(port);
+        System.out.println("[SERVER] Listening on port " + port);
+
+        // 그레이스풀 종료 훅
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try { shutdown(); } catch (Exception ignored) {}
+        }, "shutdown-hook"));
+
+        while (running) {
+            try {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                System.out.println("[SERVER] Client connected: " + socket.getRemoteSocketAddress());
+
+                ClientHandler handler = new ClientHandler(socket, broadcaster, "");
+                broadcaster.register(handler);
+                pool.execute(handler); // handler가 내부적으로 reader+writer를 운용
+            } catch (IOException e) {
+                if (running) {
+                    System.err.println("[SERVER] accept() error: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    public void shutdown() {
+        if (!running) return;
+        running = false;
+        System.out.println("[SERVER] Shutting down...");
+
+        try { if (serverSocket != null && !serverSocket.isClosed()) serverSocket.close(); }
+        catch (IOException ignored) {}
+
+        // 새 작업 중단, 큐 비움
+        pool.shutdown();
+        try {
+            if (!pool.awaitTermination(3, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            pool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+
+        broadcaster.shutdown();
+        System.out.println("[SERVER] Bye.");
+    }
+}

--- a/src/main/java/org/chatServer/util/StringValidateUtil.java
+++ b/src/main/java/org/chatServer/util/StringValidateUtil.java
@@ -1,0 +1,17 @@
+package org.chatServer.util;
+
+public class StringValidateUtil {
+
+    public static boolean validateClientNickname(String nickname) {
+        if(nickname == null) {
+            return false;
+        }
+
+        String trimmedNickname = nickname.trim();
+        return !trimmedNickname.isEmpty();
+    }
+
+    public static boolean validateQuitCommand(String message) {
+        return message.contains("/quit") || message.contains("/q");
+    }
+}


### PR DESCRIPTION
`ClientHandler.java`
- BlockingQueue 구현체 LinkedBlockingQueue 사용

`Broker` 역할의 `BroadCasterImpl.java`

1. 멀티쓰레딩 환경에서 안전한 메시지 전달을 위해
- 클라이언트가 서버와 연결하면 그 쓰레드 자원과 채팅방 역할을 수행하는 브로커 에 속하게 됨.
- (문제상황) 다른 ClientHandler 등 간에 동시에 같은 클라이언트로 메시지를 송신하려고 할 수도 있음
- (Blocking Queue) : 내부적으로 스레드 안전(thread-safe) 하게 구현되어
                                   offer(), put(), take() 같은 메서드를 사용할 때 별도 동기화를 직접 할 필요가 없음 <- 블록킹 연산
    - 따라서 여러 스레드가 동시에 enqueue 해도 안전하게 메시지를 클라이언트 송신 큐에 쌓을 수 있음

2. 쓰기 쓰레드 단일화
- (문제상황) : 소켓의 OutputStream은 동시에 여러 스레드가 쓰면 메시지가 뒤섞여 깨질 수 있음
- (문제해결) : 전용 writer 스레드 하나만 take()로 큐에서 꺼내 실제 송신하여 항상 한 스레드만 OutputStream을 다루도록
- (기대효과) : (메시지 순서보장, 충돌방지)


3. 비동기 처리와 버퍼
- BroadCaster는 단순히 queue.offer(msg)로 빠르게 메시지를 넘기고 즉시 반환 → BroadCaster가 다른 클라이언트 작업
- 송신은 writer 스레드가 큐에서 꺼내 순차적으로 처리 → 비동기 & 버퍼링 효과
